### PR TITLE
Adding py38 to tox env list

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,13 @@
+checks:
+    python:
+        code_rating: true
+        duplicate_code: true
+filter:
+    excluded_paths:
+        - '*/disabled/*'
+build:
+    tests:
+        override:
+            -
+                command: 'tox'
+            - py-scrutinizer-run

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37
+envlist = py36,py37,py38
 
 [testenv]
 deps = pytest               # PYPI package providing pytest


### PR DESCRIPTION
This PR adds python3.8 to the list of test environments at the tox.ini file